### PR TITLE
update autocmd.vim

### DIFF
--- a/config/autocmd.vim
+++ b/config/autocmd.vim
@@ -19,3 +19,24 @@ autocmd BufRead,BufNewFile .jshintrc setfiletype json
 "autocmd CursorMovedI * if pumvisible() == 0|pclose|endif
 autocmd InsertLeave * if pumvisible() == 0|pclose|endif
 
+function! CheckLeftBuffers()
+  if tabpagenr('$') == 1
+    let i = 1
+    while i <= winnr('$')
+      if getbufvar(winbufnr(i), '&buftype') == 'help' ||
+          \ getbufvar(winbufnr(i), '&buftype') == 'quickfix' ||
+          \ exists('t:NERDTreeBufName') &&
+          \   bufname(winbufnr(i)) == t:NERDTreeBufName ||
+          \ bufname(winbufnr(i)) == '__Tag_List__'
+        let i += 1
+      else
+        break
+      endif
+    endwhile
+    if i == winnr('$') + 1
+      qall
+    endif
+    unlet i
+  endif
+endfunction
+autocmd BufEnter * call CheckLeftBuffers()


### PR DESCRIPTION
Automatically quit vim if actual files are closed.
NERDTree stays open when there is no file open. 
This solution was found https://yous.be/2014/11/30/automatically-quit-vim-if-actual-files-are-closed/